### PR TITLE
Add stack.yaml, make compatible with GHC 8.2.2 and add travis config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,26 @@
-language: haskell
-ghc:
-  - "7.6"
-  - "7.8"
-  # disabled because travis doesn't yet support it
-  # - "7.10"
 sudo: false
-notifications:
-  email: false
+
+language: generic
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.stack
+
+before_install:
+  # Download and unpack the stack executable
+  - mkdir -p ~/.local/bin
+  - export PATH=$HOME/.local/bin:$PATH
+  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+
+matrix:
+  include:
+    - env: STACK_YAML=stack-lts-2.22 # GHC 7.8.4
+    - env: STACK_YAML=stack-lts-3.22 # GHC 7.10.2
+    - env: STACK_YAML=stack-lts-6.35 # GHC 7.10.3
+    - env: STACK_YAML=stack-lts-7.24 # GHC 8.0.1
+    - env: STACK_YAML=stack-lts-9.14 # GHC 8.0.2
+    - env: STACK_YAML=stack-nightly  # GHC 8.2.2
+
+script:
+  - travis_wait 180 stack --no-terminal --install-ghc --skip-ghc-check test

--- a/src/Control/Monad/Trans/Stitch.hs
+++ b/src/Control/Monad/Trans/Stitch.hs
@@ -8,7 +8,7 @@ import Control.Applicative
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Writer.Strict
-import Data.Monoid
+import Data.Monoid (Monoid(..))
 
 newtype StitchT m a = StitchT (WriterT Block m a)
   deriving (Functor, Applicative, Monad, Alternative, MonadIO, MonadTrans)

--- a/stack-lts-2.22
+++ b/stack-lts-2.22
@@ -1,0 +1,1 @@
+resolver: lts-2.22

--- a/stack-lts-3.22
+++ b/stack-lts-3.22
@@ -1,0 +1,1 @@
+resolver: lts-3.22

--- a/stack-lts-6.35
+++ b/stack-lts-6.35
@@ -1,0 +1,1 @@
+resolver: lts-6.35

--- a/stack-lts-7.24
+++ b/stack-lts-7.24
@@ -1,0 +1,1 @@
+resolver: lts-7.24

--- a/stack-lts-9.14
+++ b/stack-lts-9.14
@@ -1,0 +1,1 @@
+resolver: lts-9.14

--- a/stack-nightly
+++ b/stack-nightly
@@ -1,0 +1,1 @@
+resolver: nightly-2017-11-25

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,1 @@
+resolver: lts-9.14

--- a/stitch.cabal
+++ b/stitch.cabal
@@ -28,7 +28,7 @@ library
     Stitch.Types
     Stitch.Types.Selector
   build-depends:
-    base >= 4.6 && < 4.10,
+    base >= 4.6 && < 4.11,
     containers,
     text,
     transformers


### PR DESCRIPTION
Hi @intolerable 

First of all thank you for this library, I started using it for some templating in my personal blog and it's great!

Yesterday I tried to compile it using GHC `8.2.2` (and nightly stackage snapshot) but had some issue with the upper bond version for `base`. I took the liberty to add a `stack.yaml` config as well as updated travis config to make use of `stack` and test against all versions of GHC and different snapshots. Let me know if you think it makes sense or is desirable for the project.

Cheers,