### PR TITLE
Add support for GHC 8.4.x and update travis config

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -31,7 +31,7 @@ library:
     - Stitch.Types
     - Stitch.Types.Selector
   dependencies:
-    - base >=4.6 && <4.11
+    - base >=4.6 && <4.12
     - containers
     - text
     - transformers

--- a/src/Control/Monad/Trans/Stitch.hs
+++ b/src/Control/Monad/Trans/Stitch.hs
@@ -8,14 +8,18 @@ import Control.Applicative
 import Control.Monad.IO.Class
 import Control.Monad.Trans.Class
 import Control.Monad.Trans.Writer.Strict
+import Data.Semigroup
 import Data.Monoid (Monoid(..))
 
 newtype StitchT m a = StitchT (WriterT Block m a)
   deriving (Functor, Applicative, Monad, Alternative, MonadIO, MonadTrans)
 
-instance (Applicative m, Monoid a) => Monoid (StitchT m a) where
+instance (Applicative m, Semigroup a) => Semigroup (StitchT m a) where
+  a <> b = (<>) <$> a <*> b
+
+instance (Applicative m, Monoid a, Semigroup a) => Monoid (StitchT m a) where
   mempty = pure mempty
-  a `mappend` b = mappend <$> a <*> b
+  mappend = (<>)
 
 runStitchT :: Monad m => StitchT m a -> m (a, Block)
 runStitchT (StitchT x) = runWriterT x

--- a/src/Stitch/Types.hs
+++ b/src/Stitch/Types.hs
@@ -10,18 +10,22 @@ module Stitch.Types
 import Stitch.Types.Selector
 
 import Data.Map (Map)
-import Data.Monoid
 import Data.Text (Text)
+import Data.Semigroup
 import qualified Data.Map as Map
 
 -- | Children is a simple specialized wrapper around 'Map' with a custom 'Monoid' instance. Instead of simply 'Data.Map.union'ing the two 'Map's, the 'Children' instance 'mappend's the two values together in case of a key clash.
 newtype Children = Children (Map Selector InnerBlock)
   deriving (Show, Read, Eq)
 
+instance Semigroup Children where
+  Children x <> Children y =
+    Children (Map.unionWith mappend x y)
+
 instance Monoid Children where
   mempty = Children mempty
-  Children x `mappend` Children y =
-    Children (Map.unionWith mappend x y)
+  mappend = (<>)
+
 
 -- | Type for a CSS property or comment. The two are combined because we want to keep the ordering of comments and properties in the output CSS.
 data Property = Property Text Text
@@ -36,16 +40,22 @@ newtype Import = Import Text
 data InnerBlock = InnerBlock [Property] Children
   deriving (Show, Read, Eq)
 
+instance Semigroup InnerBlock where
+  InnerBlock p c <> InnerBlock q d =
+    InnerBlock (p <> q) (c <> d)
+
 instance Monoid InnerBlock where
   mempty = InnerBlock [] mempty
-  InnerBlock p c `mappend` InnerBlock q d =
-    InnerBlock (p <> q) (c <> d)
+  mappend = (<>)
 
 -- | Top-level representation of a CSS document.
 data Block = Block [Import] [Property] Children
   deriving (Show, Read, Eq)
 
+instance Semigroup Block where
+  Block i p c <> Block j q d =
+    Block (i <> j) (p <> q) (c <> d)
+
 instance Monoid Block where
   mempty = Block mempty mempty mempty
-  Block i p c `mappend` Block j q d =
-    Block (i <> j) (p <> q) (c <> d)
+  mappend = (<>)

--- a/src/Stitch/Types/Selector.hs
+++ b/src/Stitch/Types/Selector.hs
@@ -4,8 +4,8 @@ module Stitch.Types.Selector
   , fromText ) where
 
 import Data.Text (Text)
-import Data.Monoid
 import Data.String
+import Data.Semigroup
 import qualified Data.Text as Text
 
 -- | Represents a CSS selector. Can be combined with other 'Selector's using its 'Monoid' instance.
@@ -15,17 +15,21 @@ newtype Selector = Selector { unSelector :: [Text] }
 instance IsString Selector where
   fromString = fromText . fromString
 
-instance Monoid Selector where
-  mempty = Selector []
-  Selector [] `mappend` Selector ys = Selector ys
-  Selector xs `mappend` Selector [] = Selector xs
-  Selector xs `mappend` Selector ys =
+instance Semigroup Selector where
+  Selector [] <> Selector ys = Selector ys
+  Selector xs <> Selector [] = Selector xs
+  Selector xs <> Selector ys =
     Selector $ do
       x <- xs
       y <- ys
       if Text.isInfixOf "&" y
         then return $ Text.replace "&" x y
         else return $ x <> " " <> y
+
+instance Monoid Selector where
+  mempty = Selector []
+  mappend = (<>)
+
 
 -- | Parse a 'Selector' from a 'Text' value. This is the same function used by the 'IsString' instance used by @OverloadedStrings@.
 fromText :: Text -> Selector

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-resolver: lts-11.8
+resolver: lts-12.0


### PR DESCRIPTION
Hi there,

I just noticed that there is a new [Stackage snapshot](https://www.stackage.org/lts-12.0) running with GHC 8.4.3 available. This PR makes `stitch` compatible with this newer compiler version. Only minor changes were needed: providing a `SemiGroup` instance for `Monoids`. It is not strictly needed to provide a `mappend` implementation for monoids anymore, but I think we need to keep it for backward compatibility.

Let me know if I can do anything else,
Rémi